### PR TITLE
Prototype "cred bounties" via manual weights

### DIFF
--- a/weights.json
+++ b/weights.json
@@ -34,7 +34,12 @@
         "forwards": 2
       }
     },
-    "nodeManualWeights": {},
+    "nodeManualWeights": {
+      "N\u0000sourcecred\u0000discourse\u0000topic\u0000https://discourse.sourcecred.io\u0000248\u0000": 8,
+      "N\u0000sourcecred\u0000discourse\u0000topic\u0000https://discourse.sourcecred.io\u0000269\u0000": 4,
+      "N\u0000sourcecred\u0000discourse\u0000topic\u0000https://discourse.sourcecred.io\u0000270\u0000": 4,
+      "N\u0000sourcecred\u0000discourse\u0000topic\u0000https://discourse.sourcecred.io\u0000291\u0000": 4
+    },
     "nodeTypeWeights": {
       "N\u0000sourcecred\u0000discourse\u0000post\u0000": 2,
       "N\u0000sourcecred\u0000discourse\u0000topic\u0000": 8,


### PR DESCRIPTION
This is a small experiment in having something like [Cred Bounties][1]
before we've actually implemented the [Initiatives Plugin][2].

Basically, we're giving a higher weight to a few initiatives:
- Produce the SourceCred Podcast: Shipped the podcast!
- Discourse Reference Detection: Recently completed.
- Champions & Heroes: An exciting contribution. :)
- Initiatives Plugin: Nice progress so far.

The weight choices are moderate, so it doesn't have a _huge_ effect on
cred--we'll hold off on big effects for after the initiatives plugin and
cred bounties both land. But this is a nice way to recognize some
exciting progress so far.

[1]: https://discourse.sourcecred.io/t/enable-cred-bounties/257
[2]: https://discourse.sourcecred.io/t/write-the-initiatives-plugin/269