### PR TITLE
convert weights to 0.2.0 format

### DIFF
--- a/weights.json
+++ b/weights.json
@@ -1,10 +1,10 @@
 [
   {
     "type": "sourcecred/weights",
-    "version": "0.1.0"
+    "version": "0.2.0"
   },
   {
-    "edgeTypeWeights": {
+    "edgeWeights": {
       "E\u0000sourcecred\u0000discourse\u0000authors\u0000post\u0000": {
         "backwards": 1,
         "forwards": 0.125
@@ -34,14 +34,12 @@
         "forwards": 2
       }
     },
-    "nodeManualWeights": {
+    "nodeWeights": {
       "N\u0000sourcecred\u0000discourse\u0000topic\u0000https://discourse.sourcecred.io\u0000248\u0000": 8,
       "N\u0000sourcecred\u0000discourse\u0000topic\u0000https://discourse.sourcecred.io\u0000269\u0000": 4,
       "N\u0000sourcecred\u0000discourse\u0000topic\u0000https://discourse.sourcecred.io\u0000270\u0000": 4,
       "N\u0000sourcecred\u0000discourse\u0000topic\u0000https://discourse.sourcecred.io\u0000291\u0000": 4,
-      "N\u0000sourcecred\u0000discourse\u0000topic\u0000https://discourse.sourcecred.io\u0000327\u0000": 4
-    },
-    "nodeTypeWeights": {
+      "N\u0000sourcecred\u0000discourse\u0000topic\u0000https://discourse.sourcecred.io\u0000327\u0000": 4,
       "N\u0000sourcecred\u0000discourse\u0000post\u0000": 2,
       "N\u0000sourcecred\u0000discourse\u0000topic\u0000": 8,
       "N\u0000sourcecred\u0000discourse\u0000user\u0000": 0,


### PR DESCRIPTION
This update is needed as of sourcecred/sourcecred#1558. I didn't make
any changes to the weights themselves. As discussed in the review there,
the weights semantics changed in some edge cases; happily, none of those
edge cases were present in our weights.

Test plan: I've re-computed cred using the new weights (built against
sourcecred master) and verified that the weights are set correctly in
the UI.