### PR TITLE
Change distribution history to account for rename

### DIFF
--- a/distributionHistory.json
+++ b/distributionHistory.json
@@ -9460,7 +9460,7 @@
                 "slow": 185
             },
             {
-                "alias": "discourse/@sabba",
+                "alias": "sourcecred/@amico",
                 "fast": 643,
                 "slow": 603
             },
@@ -9793,7 +9793,7 @@
                 "slow": 0
             },
             {
-                "alias": "discourse/@sabba",
+                "alias": "sourcecred/@amico",
                 "fast": 5107,
                 "slow": 3240
             },
@@ -10376,7 +10376,7 @@
                 "slow": 0
             },
             {
-                "alias": "discourse/@sabba",
+                "alias": "sourcecred/@amico",
                 "fast": 3681,
                 "slow": 3024
             },


### PR DESCRIPTION
Since the grain distribution tracker is not yet aware of the identities
plugin, now that we've created an identity for amico (cf #18), we should
rewrite history so that the past distributions to amico are recorded
properly.

Test plan: `git grep sabba` returns no hits.