### PR TITLE
Rename sourcecred-action to github-workflow-examples

### DIFF
--- a/project.json
+++ b/project.json
@@ -44,7 +44,7 @@
         "owner": "sourcecred"
       },
       {
-        "name": "sourcecred-action",
+        "name": "github-workflow-examples",
         "owner": "sourcecred"
       },
       {


### PR DESCRIPTION
Assumes #22 is merged.

The repository itself was renamed. See https://github.com/sourcecred/github-workflow-examples/pull/42