### PR TITLE
Add first batch of CredCon and Partner initiatives

### DIFF
--- a/initiatives/2020-02-credcon-adoption-meeting.json
+++ b/initiatives/2020-02-credcon-adoption-meeting.json
@@ -1,0 +1,24 @@
+[
+  {
+    "type": "sourcecred/initiativeFile",
+    "version": "0.1.0"
+  },
+  {
+    "title": "CredCon: adoption meeting",
+    "timestampIso": "2020-02-10T10:00:00.000Z",
+    "weight": {
+      "incomplete": 400,
+      "complete": 400
+    },
+    "_fibonacciWeight": 2,
+    "completed": true,
+    "champions": [
+      "https://discourse.sourcecred.io/u/decentralion"
+    ],
+    "dependencies": [
+      "https://github.com/sourcecred/cred/tree/master/initiatives/2020-02-credcon.json"
+    ],
+    "references": [],
+    "contributions": []
+  }
+]

--- a/initiatives/2020-02-credcon-adoption-meeting.json
+++ b/initiatives/2020-02-credcon-adoption-meeting.json
@@ -7,8 +7,8 @@
     "title": "CredCon: adoption meeting",
     "timestampIso": "2020-02-10T10:00:00.000Z",
     "weight": {
-      "incomplete": 400,
-      "complete": 400
+      "incomplete": 200,
+      "complete": 200
     },
     "_fibonacciWeight": 2,
     "completed": true,

--- a/initiatives/2020-02-credcon-buidl-talk.json
+++ b/initiatives/2020-02-credcon-buidl-talk.json
@@ -7,8 +7,8 @@
     "title": "CredCon: #BUIDL talk",
     "timestampIso": "2020-02-10T10:00:00.000Z",
     "weight": {
-      "incomplete": 400,
-      "complete": 400
+      "incomplete": 200,
+      "complete": 200
     },
     "_fibonacciWeight": 2,
     "completed": true,

--- a/initiatives/2020-02-credcon-buidl-talk.json
+++ b/initiatives/2020-02-credcon-buidl-talk.json
@@ -1,0 +1,24 @@
+[
+  {
+    "type": "sourcecred/initiativeFile",
+    "version": "0.1.0"
+  },
+  {
+    "title": "CredCon: #BUIDL talk",
+    "timestampIso": "2020-02-10T10:00:00.000Z",
+    "weight": {
+      "incomplete": 400,
+      "complete": 400
+    },
+    "_fibonacciWeight": 2,
+    "completed": true,
+    "champions": [
+      "https://discourse.sourcecred.io/u/decentralion"
+    ],
+    "dependencies": [
+      "https://github.com/sourcecred/cred/tree/master/initiatives/2020-02-credcon.json"
+    ],
+    "references": [],
+    "contributions": []
+  }
+]

--- a/initiatives/2020-02-credcon-car.json
+++ b/initiatives/2020-02-credcon-car.json
@@ -1,0 +1,23 @@
+[
+  {
+    "type": "sourcecred/initiativeFile",
+    "version": "0.1.0"
+  },
+  {
+    "title": "CredCon: car",
+    "timestampIso": "2020-02-10T10:00:00.000Z",
+    "weight": {
+      "incomplete": 400,
+      "complete": 400
+    },
+    "_fibonacciWeight": 2,
+    "completed": true,
+    "champions": [
+      "https://discourse.sourcecred.io/u/decentralion",
+      "https://discourse.sourcecred.io/u/lb"
+    ],
+    "dependencies": [],
+    "references": [],
+    "contributions": []
+  }
+]

--- a/initiatives/2020-02-credcon-car.json
+++ b/initiatives/2020-02-credcon-car.json
@@ -7,8 +7,8 @@
     "title": "CredCon: car",
     "timestampIso": "2020-02-10T10:00:00.000Z",
     "weight": {
-      "incomplete": 400,
-      "complete": 400
+      "incomplete": 200,
+      "complete": 200
     },
     "_fibonacciWeight": 2,
     "completed": true,

--- a/initiatives/2020-02-credcon-food.json
+++ b/initiatives/2020-02-credcon-food.json
@@ -7,8 +7,8 @@
     "title": "CredCon: food",
     "timestampIso": "2020-02-10T10:00:00.000Z",
     "weight": {
-      "incomplete": 1000,
-      "complete": 1000
+      "incomplete": 500,
+      "complete": 500
     },
     "_fibonacciWeight": 5,
     "completed": true,

--- a/initiatives/2020-02-credcon-food.json
+++ b/initiatives/2020-02-credcon-food.json
@@ -1,0 +1,25 @@
+[
+  {
+    "type": "sourcecred/initiativeFile",
+    "version": "0.1.0"
+  },
+  {
+    "title": "CredCon: food",
+    "timestampIso": "2020-02-10T10:00:00.000Z",
+    "weight": {
+      "incomplete": 1000,
+      "complete": 1000
+    },
+    "_fibonacciWeight": 5,
+    "completed": true,
+    "champions": [
+      "https://discourse.sourcecred.io/u/lb",
+      "https://discourse.sourcecred.io/u/flyingzumwalt"
+    ],
+    "dependencies": [
+      "https://github.com/sourcecred/cred/tree/master/initiatives/2020-02-credcon-car.json"
+    ],
+    "references": [],
+    "contributions": []
+  }
+]

--- a/initiatives/2020-02-credcon-hackathon.json
+++ b/initiatives/2020-02-credcon-hackathon.json
@@ -7,8 +7,8 @@
     "title": "CredCon: hackathon",
     "timestampIso": "2020-02-10T10:00:00.000Z",
     "weight": {
-      "incomplete": 600,
-      "complete": 600
+      "incomplete": 300,
+      "complete": 300
     },
     "_fibonacciWeight": 3,
     "completed": true,

--- a/initiatives/2020-02-credcon-hackathon.json
+++ b/initiatives/2020-02-credcon-hackathon.json
@@ -1,0 +1,24 @@
+[
+  {
+    "type": "sourcecred/initiativeFile",
+    "version": "0.1.0"
+  },
+  {
+    "title": "CredCon: hackathon",
+    "timestampIso": "2020-02-10T10:00:00.000Z",
+    "weight": {
+      "incomplete": 600,
+      "complete": 600
+    },
+    "_fibonacciWeight": 3,
+    "completed": true,
+    "champions": [
+      "https://discourse.sourcecred.io/u/decentralion"
+    ],
+    "dependencies": [
+      "https://github.com/sourcecred/cred/tree/master/initiatives/2020-02-credcon.json"
+    ],
+    "references": [],
+    "contributions": []
+  }
+]

--- a/initiatives/2020-02-credcon-lodging.json
+++ b/initiatives/2020-02-credcon-lodging.json
@@ -7,8 +7,8 @@
     "title": "CredCon: lodging",
     "timestampIso": "2020-02-10T10:00:00.000Z",
     "weight": {
-      "incomplete": 1000,
-      "complete": 1000
+      "incomplete": 500,
+      "complete": 500
     },
     "_fibonacciWeight": 5,
     "completed": true,

--- a/initiatives/2020-02-credcon-lodging.json
+++ b/initiatives/2020-02-credcon-lodging.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "sourcecred/initiativeFile",
+    "version": "0.1.0"
+  },
+  {
+    "title": "CredCon: lodging",
+    "timestampIso": "2020-02-10T10:00:00.000Z",
+    "weight": {
+      "incomplete": 1000,
+      "complete": 1000
+    },
+    "_fibonacciWeight": 5,
+    "completed": true,
+    "champions": [
+      "https://discourse.sourcecred.io/u/lb"
+    ],
+    "dependencies": [],
+    "references": [],
+    "contributions": []
+  }
+]

--- a/initiatives/2020-02-credcon-party.json
+++ b/initiatives/2020-02-credcon-party.json
@@ -1,0 +1,24 @@
+[
+  {
+    "type": "sourcecred/initiativeFile",
+    "version": "0.1.0"
+  },
+  {
+    "title": "CredCon: party",
+    "timestampIso": "2020-02-10T10:00:00.000Z",
+    "weight": {
+      "incomplete": 400,
+      "complete": 400
+    },
+    "_fibonacciWeight": 2,
+    "completed": true,
+    "champions": [
+      "https://discourse.sourcecred.io/u/lb"
+    ],
+    "dependencies": [
+      "https://github.com/sourcecred/cred/tree/master/initiatives/2020-02-credcon.json"
+    ],
+    "references": [],
+    "contributions": []
+  }
+]

--- a/initiatives/2020-02-credcon-party.json
+++ b/initiatives/2020-02-credcon-party.json
@@ -7,8 +7,8 @@
     "title": "CredCon: party",
     "timestampIso": "2020-02-10T10:00:00.000Z",
     "weight": {
-      "incomplete": 400,
-      "complete": 400
+      "incomplete": 200,
+      "complete": 200
     },
     "_fibonacciWeight": 2,
     "completed": true,

--- a/initiatives/2020-02-credcon-sustain-web3-talk.json
+++ b/initiatives/2020-02-credcon-sustain-web3-talk.json
@@ -1,0 +1,25 @@
+[
+  {
+    "type": "sourcecred/initiativeFile",
+    "version": "0.1.0"
+  },
+  {
+    "title": "CredCon: Sustain Web3 talk",
+    "timestampIso": "2020-02-10T10:00:00.000Z",
+    "weight": {
+      "incomplete": 1000,
+      "complete": 1000
+    },
+    "_fibonacciWeight": 5,
+    "completed": true,
+    "champions": [
+      "https://discourse.sourcecred.io/u/decentralion"
+    ],
+    "dependencies": [
+      "https://github.com/sourcecred/cred/tree/master/initiatives/2020-02-credcon.json",
+      "https://github.com/sourcecred/cred/tree/master/initiatives/2020-02-credcon-buidl-talk.json"
+    ],
+    "references": [],
+    "contributions": []
+  }
+]

--- a/initiatives/2020-02-credcon-sustain-web3-talk.json
+++ b/initiatives/2020-02-credcon-sustain-web3-talk.json
@@ -7,8 +7,8 @@
     "title": "CredCon: Sustain Web3 talk",
     "timestampIso": "2020-02-10T10:00:00.000Z",
     "weight": {
-      "incomplete": 1000,
-      "complete": 1000
+      "incomplete": 500,
+      "complete": 500
     },
     "_fibonacciWeight": 5,
     "completed": true,

--- a/initiatives/2020-02-credcon.json
+++ b/initiatives/2020-02-credcon.json
@@ -1,0 +1,32 @@
+[
+  {
+    "type": "sourcecred/initiativeFile",
+    "version": "0.1.0"
+  },
+  {
+    "title": "CredCon",
+    "timestampIso": "2020-02-10T10:00:00.000Z",
+    "weight": {
+      "incomplete": 0,
+      "complete": 0
+    },
+    "_fibonacciWeight": 0,
+    "completed": true,
+    "champions": [
+      "https://discourse.sourcecred.io/u/decentralion",
+      "https://discourse.sourcecred.io/u/lb"
+    ],
+    "dependencies": [
+      "https://github.com/sourcecred/cred/tree/master/initiatives/2020-02-credcon-car.json",
+      "https://github.com/sourcecred/cred/tree/master/initiatives/2020-02-credcon-food.json",
+      "https://github.com/sourcecred/cred/tree/master/initiatives/2020-02-credcon-lodging.json"
+    ],
+    "references": [
+      "https://discourse.sourcecred.io/t/credcon/531",
+      "https://discourse.sourcecred.io/t/meeting-notes-credcon-schedule-agenda/598"
+    ],
+    "contributions": [
+      "https://discourse.sourcecred.io/t/credcon-everything-you-need-to-know/559"
+    ]
+  }
+]

--- a/initiatives/2020-02-partner-maker.json
+++ b/initiatives/2020-02-partner-maker.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "sourcecred/initiativeFile",
+    "version": "0.1.0"
+  },
+  {
+    "title": "Partner Maker",
+    "timestampIso": "2020-02-10T10:00:00.000Z",
+    "weight": {
+      "incomplete": 1600,
+      "complete": 1600
+    },
+    "_fibonacciWeight": 8,
+    "completed": false,
+    "champions": [
+      "https://discourse.sourcecred.io/u/s_ben"
+    ],
+    "dependencies": [],
+    "references": [],
+    "contributions": []
+  }
+]

--- a/initiatives/2020-02-partner-maker.json
+++ b/initiatives/2020-02-partner-maker.json
@@ -7,8 +7,8 @@
     "title": "Partner Maker",
     "timestampIso": "2020-02-10T10:00:00.000Z",
     "weight": {
-      "incomplete": 1600,
-      "complete": 1600
+      "incomplete": 800,
+      "complete": 800
     },
     "_fibonacciWeight": 8,
     "completed": false,

--- a/initiatives/2020-02-partner-metagame.json
+++ b/initiatives/2020-02-partner-metagame.json
@@ -7,8 +7,8 @@
     "title": "Partner MetaGame",
     "timestampIso": "2020-02-10T10:00:00.000Z",
     "weight": {
-      "incomplete": 1600,
-      "complete": 1600
+      "incomplete": 800,
+      "complete": 800
     },
     "_fibonacciWeight": 8,
     "completed": false,

--- a/initiatives/2020-02-partner-metagame.json
+++ b/initiatives/2020-02-partner-metagame.json
@@ -1,0 +1,24 @@
+[
+  {
+    "type": "sourcecred/initiativeFile",
+    "version": "0.1.0"
+  },
+  {
+    "title": "Partner MetaGame",
+    "timestampIso": "2020-02-10T10:00:00.000Z",
+    "weight": {
+      "incomplete": 1600,
+      "complete": 1600
+    },
+    "_fibonacciWeight": 8,
+    "completed": false,
+    "champions": [
+      "https://github.com/hammadj"
+    ],
+    "dependencies": [
+      "https://github.com/sourcecred/cred/tree/master/initiatives/2020-02-credcon.json"
+    ],
+    "references": [],
+    "contributions": []
+  }
+]


### PR DESCRIPTION
Depends on #26

## This is a first iteration

_Edit: rather than letting this stall for too long, let's improve on this with follow ups.
Have a look at #29 for info on how to go from here._

This is ~~a preview~~ a first iteration, as it's in need of another weighting round.
Still missing from this, but identified at the team call:
- CredCon: video interviews (need a user account for zak)
- CredCon: CredRank prototype (have not decided fibonacci weight)
- CredCon: Discord prototype (have not decided fibonacci weight)
- Evan's explainer (have not decided fibonacci weight)

Also great improvements to make from here:
- Adding contributions and linking that to contributors (see #30)

Good but not as critical:
- Making the timestamps more accurate


## Assumptions to validate


### Fibonacci to absolute weights: 200x

_Edit: see https://github.com/sourcecred/cred/pull/27#issuecomment-610607504 we'll start out with 100x for this PR, then move to 200x when we're more confident about having solid coverage of connected contributions._

The major point to debate is the weights we should set. In the team call
we've decided on fibonacci scale weights, which I've included in these
files as `_fibonacciWeight`.

This PR includes a ballpark suggestion of a multiplier to use.
The intention is to "inflate cred" by weighing initiatives more heavily
than plugin-imported contributions so far. While keeping in mind that
more initiatives will follow and inflate cred further. And adding more
contribution edges will "dilute" the share currently flowing to champions.

A multiplier which I think is in this ballpark is: 200x
(e.g. a fibonacci weight of 2 = a node weight of 400)


### Dependency structure

For the activities as part of CredCon (like hackathon, party, talks), I
found they had very similar dependencies on logistical initiatives and
CredCon itself. I've generalized this by depending on CredCon, rather than
directly depending on logistics.

Example: CredCon party, depends on CredCon, depends on car+food+lodging

This will make the life of historians easier too, as adding more logicstics
(maybe invites or scheduling) would only need to be set as a CredCon
dependency, rather than for all activities as well.


### Example references / contributions

For the main CredCon initiative, I've added several clearly related forum
topics. These are both as an example, and to make sure this part of the
graph is not exclusively connected through identities.


### Completion status

Other than both Partner initiatives, the CredCon initiatives are set as
completed.


## Technical aspects to validate

The main point which needs careful manual validation, is to inspect the
graph. For example using the "legacy explorer" to confirm the initiative
nodes are added and have edges to *all* the URLs added.

That means:
- Champions: Identities / GitHub users / Discourse users.
- References / Contributions: Forum topics (in CredCon).
- Dependencies between Initiatives.

Note: it's expected for links to an initiative to give a 404 not found,
until the PR is merged to master. However they should be listed in the
explorer.