### PR TITLE
Add identity for burrrata

### DIFF
--- a/project.json
+++ b/project.json
@@ -27,7 +27,8 @@
       {"username": "hammadj", "aliases": ["github/hammadj", "discourse/meta_dreamer"]},
       {"username": "miyazono", "aliases": ["github/miyazono", "discourse/miyazono"]},
       {"username": "LB", "aliases": ["github/LexBirdie", "discourse/LB"]},
-      {"username": "Bex", "aliases": ["github/Bex2594", "discourse/Bex", "discourse/Bex2594"]}
+      {"username": "Bex", "aliases": ["github/Bex2594", "discourse/Bex", "discourse/Bex2594"]},
+      {"username": "burrrata", "aliases": ["github/burrrata", "discourse/burrrata"]}
     ],
     "repoIds": [
       {


### PR DESCRIPTION
Hadn't yet mapped @burrrata's identity :open_mouth:

Test plan: loaded with updated `project.json` and verified the explorer includes the merged identity.