### PR TITLE
Try to deploy without touching symlinks

### DIFF
--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -39,10 +39,6 @@ jobs:
       - name: Generate Frontend 🏗
         run: |
           yarn site
-          cp -rf ./output ./site
-          cp -rf ./data ./site
-          cp -rf ./config ./site
-          cp -f ./sourcecred.json ./site
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.5.7


### PR DESCRIPTION
This commit will probably produce a broken deployment with broken symlinks. But I want to give it a try because it'd be really convenient if this somehow Just Worked.

Test plan: Merge, and see if the resultant build works. Dubious but possible.

cc @hammadj 