### PR TITLE
An action for distributing Grain

### DIFF
--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           echo ::set-env name=PULL_REQUEST_TITLE::"Scheduled grain distribution for week ending $(date +"%B %dth, %Y")"
           echo ::set-env name=PULL_REQUEST_BODY::"This PR was auto-generated on $(date +%d-%m-%Y) \
-            to add the latest grain distribution to our instance. $(cat grain_output.txt)"
+            to add the latest grain distribution to our instance. <br /> <br />  $(cat grain_output.txt)"
           rm grain_output.txt
 
       - name: Create commit and PR for ledger changes

--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -6,7 +6,10 @@ on:
     - cron: 5 0 * * 0 # 00:05 UTC, 16:05 PST
   push:
     branches:
-      - "graintest-*" # won't actually update ledger or deploy frontend
+      # allows us to test this workflow, or manually generate distributions
+      # PRSs created from grain-trigger-* branches are targeted
+      # on their immediate base branches, as opposed to master
+      - "grain-trigger-*"
 
 jobs:
   distribute-grain:

--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -17,11 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: "[debug] Check GitHub event name"
-        # This is used to determine whether we actually deploy to GitHub
-        # Pages, so we print it upfront to aid with debugging.
-        run: echo ${{ github.event_name }}
-
       - name: Install Packages 🔧
         run: |
           yarn --frozen-lockfile

--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -35,13 +35,14 @@ jobs:
 
       - name: Distribute Grain 💸
         run: |
-          yarn grain
+          yarn grain > grain_output.txt
 
       - name: Set environment variables
         run: |
           echo ::set-env name=PULL_REQUEST_TITLE::"Scheduled grain distribution for week ending $(date +"%B %dth, %Y")"
           echo ::set-env name=PULL_REQUEST_BODY::"This PR was auto-generated on $(date +%d-%m-%Y) \
-            to add the latest grain distribution to our instance."
+            to add the latest grain distribution to our instance. $(cat grain_output.txt)"
+          rm grain_output.txt
 
       - name: Create commit and PR for ledger changes
         id: pr

--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -23,12 +23,12 @@ jobs:
 
       - name: Install Packages 🔧
         run: |
-          cd $GITHUB_WORKSPACE/calc
+          cd calc
           yarn --frozen-lockfile
 
       - name: Load Data into Graph 🔌
         run: |
-          cd $GITHUB_WORKSPACE/calc
+          cd calc
           yarn load
           yarn graph
         env:
@@ -37,17 +37,17 @@ jobs:
 
       - name: Compute Cred 🧮
         run: |
-          cd $GITHUB_WORKSPACE/calc
+          cd calc
           yarn score
 
       - name: Distribute Grain 💸
         run: |
-          cd $GITHUB_WORKSPACE/calc
+          cd calc
           yarn grain
 
       - name: Commit Ledger 💾
         run: |
-          cd $GITHUB_WORKSPACE/calc
+          cd calc
           git config user.name 'credbot'
           git config user.email 'credbot@users.noreply.github.com'
           git add data/ledger.json
@@ -56,7 +56,7 @@ jobs:
       - name: Push Ledger
         if: "${{ github.event_name == 'schedule' }}"  
         run: |
-          cd $GITHUB_WORKSPACE/calc
+          cd calc
           git push
 
       # This is needed to delete git credentials

--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          path: calc
 
       - name: "[debug] Check GitHub event name"
         # This is used to determine whether we actually deploy to GitHub
@@ -23,12 +21,10 @@ jobs:
 
       - name: Install Packages 🔧
         run: |
-          cd calc
           yarn --frozen-lockfile
 
       - name: Load Data into Graph 🔌
         run: |
-          cd calc
           yarn load
           yarn graph
         env:
@@ -37,12 +33,10 @@ jobs:
 
       - name: Compute Cred 🧮
         run: |
-          cd calc
           yarn score
 
       - name: Distribute Grain 💸
         run: |
-          cd calc
           yarn grain
 
       - name: Set environment variables

--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -38,10 +38,17 @@ jobs:
           yarn grain > grain_output.txt
 
       - name: Set environment variables
+        id: pr_details
         run: |
           echo ::set-env name=PULL_REQUEST_TITLE::"Scheduled grain distribution for week ending $(date +"%B %dth, %Y")"
-          echo ::set-env name=PULL_REQUEST_BODY::"This PR was auto-generated on $(date +%d-%m-%Y) \
-            to add the latest grain distribution to our instance. <br /> <br />  $(cat grain_output.txt)"
+          description="This PR was auto-generated on $(date +%d-%m-%Y) \
+            to add the latest grain distribution to our instance.
+
+            $(cat grain_output.txt)"
+          description="${description//'%'/'%25'}"
+          description="${description//$'\n'/'%0A'}"
+          description="${description//$'\r'/'%0D'}"
+          echo "::set-output name=pr_body::$description"
           rm grain_output.txt
 
       - name: Create commit and PR for ledger changes
@@ -56,5 +63,5 @@ jobs:
           author: credbot <credbot@users.noreply.github.com>
           commit-message: update calculated ledger
           title: ${{ env.PULL_REQUEST_TITLE }}
-          body: ${{ env.PULL_REQUEST_BODY }}
+          body: ${{ steps.pr_details.outputs.pr_body }}
           reviewers: decentralion

--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          persist-credentials: false # Required to make github pages deployment work correctly
+          path: calc
 
       - name: "[debug] Check GitHub event name"
         # This is used to determine whether we actually deploy to GitHub
@@ -22,10 +22,13 @@ jobs:
         run: echo ${{ github.event_name }}
 
       - name: Install Packages 🔧
-        run: yarn --frozen-lockfile
+        run: |
+          cd $GITHUB_WORKSPACE/calc
+          yarn --frozen-lockfile
 
       - name: Load Data into Graph 🔌
         run: |
+          cd $GITHUB_WORKSPACE/calc
           yarn load
           yarn graph
         env:
@@ -33,23 +36,44 @@ jobs:
           SOURCECRED_DISCORD_TOKEN: ${{ secrets.SOURCECRED_DISCORD_TOKEN }}
 
       - name: Compute Cred 🧮
-        run: yarn score
+        run: |
+          cd $GITHUB_WORKSPACE/calc
+          yarn score
 
       - name: Distribute Grain 💸
-        run: yarn grain
+        run: |
+          cd $GITHUB_WORKSPACE/calc
+          yarn grain
 
       - name: Commit Ledger 💾
-        uses: stefanzweifel/git-auto-commit-action@v4
-        if: "${{ github.event_name == 'schedule' }}"
+        run: |
+          cd $GITHUB_WORKSPACE/calc
+          git config user.name 'credbot'
+          git config user.email 'credbot@users.noreply.github.com'
+          git add data/ledger.json
+          git commit --allow-empty -m 'Auto-update ledger'
+
+      - name: Push Ledger
+        if: "${{ github.event_name == 'schedule' }}"  
+        run: |
+          cd $GITHUB_WORKSPACE/calc
+          git push
+      
+      # This is needed to delete git credentials
+      # in preparation for publishing the new details
+      - name: Checkout HEAD again
+        uses: actions/checkout@v2
         with:
-          commit_message: Auto-update ledger
-          file_pattern: data/ledger.json
+          persist-credentials: false
+
+      - name: Reinstall Packages 🔧
+        run: yarn --frozen-lockfile
 
       - name: Generate Frontend 🏗
         run: |
           yarn site
           rm -rf ./site/{output,data,config,sourcecred.json}
-          cp -r ./{output,data,config,sourcecred.json} ./site/
+          cp -r $GITHUB_WORKSPACE/calc/{output,data,config,sourcecred.json} ./site/
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.5.7

--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -45,42 +45,23 @@ jobs:
           cd calc
           yarn grain
 
-      - name: Commit Ledger 💾
+      - name: Set environment variables
         run: |
-          cd calc
-          git config user.name 'credbot'
-          git config user.email 'credbot@users.noreply.github.com'
-          git add data/ledger.json
-          git commit --allow-empty -m 'Auto-update ledger'
+          echo ::set-env name=PULL_REQUEST_TITLE::"Scheduled grain distribution for week ending $(date +"%B %dth, %Y")"
+          echo ::set-env name=PULL_REQUEST_BODY::"This PR was auto-generated on $(date +%d-%m-%Y) \
+            to add the latest grain distribution to our instance."
 
-      - name: Push Ledger
-        if: "${{ github.event_name == 'schedule' }}"  
-        run: |
-          cd calc
-          git push
-
-      # This is needed to delete git credentials
-      # in preparation for publishing the new details
-      - name: Checkout HEAD again
-        uses: actions/checkout@v2
+      - name: Create commit and PR for ledger changes
+        id: pr
+        uses: peter-evans/create-pull-request@v3
         with:
-          path: deploy
-          persist-credentials: false
-
-      - name: Reinstall Packages 🔧
-        run: cd deploy && yarn --frozen-lockfile
-
-      - name: Generate Frontend 🏗
-        run: |
-          cd deploy
-          yarn site
-          rm -rf ./site/{output,data,config,sourcecred.json}
-          cp -r $GITHUB_WORKSPACE/calc/{output,data,config,sourcecred.json} ./site/
-
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@3.5.7
-        if: "${{ github.event_name == 'schedule' }}"
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: deploy/site
+          branch: generated-ledger
+          branch-suffix: timestamp
+          committer: credbot <credbot@users.noreply.github.com>
+          # author appears to be overridden when the default github action
+          # token is used for checkout
+          author: credbot <credbot@users.noreply.github.com>
+          commit-message: update calculated ledger
+          title: ${{ env.PULL_REQUEST_TITLE }}
+          body: ${{ env.PULL_REQUEST_BODY }}
+          reviewers: decentralion

--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -1,0 +1,60 @@
+name: Distribute Grain
+on:
+  # A new Cred interval every Sunday. We'll distribute Grain 5 minutes
+  # after the new interval
+  schedule:
+    - cron: 5 0 * * 0 # 00:05 UTC, 16:05 PST
+  push:
+    branches:
+      - "graintest-*" # won't actually update ledger or deploy frontend
+
+jobs:
+  distribute-grain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false # Required to make github pages deployment work correctly
+
+      - name: "[debug] Check GitHub event name"
+        # This is used to determine whether we actually deploy to GitHub
+        # Pages, so we print it upfront to aid with debugging.
+        run: echo ${{ github.event_name }}
+
+      - name: Install Packages 🔧
+        run: yarn --frozen-lockfile
+
+      - name: Load Data into Graph 🔌
+        run: |
+          yarn load
+          yarn graph
+        env:
+          SOURCECRED_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCECRED_DISCORD_TOKEN: ${{ secrets.SOURCECRED_DISCORD_TOKEN }}
+
+      - name: Compute Cred 🧮
+        run: yarn score
+
+      - name: Distribute Grain 💸
+        run: yarn grain
+
+      - name: Commit Ledger 💾
+        uses: stefanzweifel/git-auto-commit-action@v4
+        if: "${{ github.event_name == 'schedule' }}"
+        with:
+          commit_message: Auto-update ledger
+          file_pattern: data/ledger.json
+
+      - name: Generate Frontend 🏗
+        run: |
+          yarn site
+          rm -rf ./site/{output,data,config,sourcecred.json}
+          cp -r ./{output,data,config,sourcecred.json} ./site/
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@3.5.7
+        if: "${{ github.event_name == 'schedule' }}"
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: site

--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -58,19 +58,21 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/calc
           git push
-      
+
       # This is needed to delete git credentials
       # in preparation for publishing the new details
       - name: Checkout HEAD again
         uses: actions/checkout@v2
         with:
+          path: deploy
           persist-credentials: false
 
       - name: Reinstall Packages 🔧
-        run: yarn --frozen-lockfile
+        run: cd deploy && yarn --frozen-lockfile
 
       - name: Generate Frontend 🏗
         run: |
+          cd deploy
           yarn site
           rm -rf ./site/{output,data,config,sourcecred.json}
           cp -r $GITHUB_WORKSPACE/calc/{output,data,config,sourcecred.json} ./site/
@@ -81,4 +83,4 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
-          FOLDER: site
+          FOLDER: deploy/site


### PR DESCRIPTION
Summary:
This patch adds a workflow to compute grain distributions from a clean
cache on a weekly schedule, deploying the results to GitHub Pages.

Paired with @topocount.
Paired with @wchargin.

Test Plan:
Pushed to a `graintest-*` branch, spawning a test run that succeeded but
did not push to GitHub Pages (as intended):
<https://github.com/sourcecred/cred/runs/936349886>

The actual GitHub Pages push thus hasn’t been tested yet.
