### PR TITLE
Add template instance to list of repos

### DIFF
--- a/config/plugins/sourcecred/github/config.json
+++ b/config/plugins/sourcecred/github/config.json
@@ -6,6 +6,7 @@
     "sourcecred/cred",
     "sourcecred/github-workflow-examples",
     "sourcecred/docs",
-    "sourcecred/example-instance"
+    "sourcecred/example-instance",
+    "sourcecred/template-instance"
   ]
 }


### PR DESCRIPTION
New repo to be used as a starting point for users of SourceCred: https://github.com/sourcecred/template-instance