### PR TITLE
Add dependency minting on SourceCred itself

### DIFF
--- a/config/dependencies.json
+++ b/config/dependencies.json
@@ -1,0 +1,7 @@
+[
+    {
+        "id": "Ec60d6PWymrN0ylmsZOHkg",
+        "name": "sourcecred",
+        "startWeight": 0.1
+    }
+]


### PR DESCRIPTION
This adds the SourceCred project as a self-dependency. By minting Cred
for sourcecred itself, this mean we will naturally start to flow a
fraction of our Grain to the SourceCred organization, establishing a
project treasury that we can use for funding grants, paying for events,
etc.