### PR TITLE
Change cred calculation interval from 6 to 24 hours

### DIFF
--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - master
-  # As well as every 6 hours.
+  # As well as every 24 hours (at 0:00 UTC).
   schedule:
-    - cron: 0 */6 * * *
+    - cron: 0 0 * * *
 
 jobs:
   GenerateCredInstance:


### PR DESCRIPTION
This changes the cred computation to occurs every 24 hours at 0:00 UTC. This change will be verified once merged.