### PR TITLE
Re-add the yarn serve command

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "clean-all": "yarn clean && rimraf output",
     "load": "dotenv sourcecred load",
     "start": "dotenv -- sourcecred go --no-load && sourcecred serve",
+    "serve": "sourcecred serve",
     "grain": "sourcecred grain"
   },
   "devDependencies": {


### PR DESCRIPTION
This puts `yarn serve` back in, which was removed in #138.
It's convenient to be able to turn on the server (e.g. to inspect the
ledger) without needing to reload everything.