### PR TITLE
November LB to Joie Transfer

### DIFF
--- a/data/ledger.json
+++ b/data/ledger.json
@@ -1457,3 +1457,4 @@
 {"action":{"identityId":"PvvajUW54QpDCWOP3ZO69g","type":"TOGGLE_ACTIVATION"},"ledgerTimestamp":1606417809157,"uuid":"TozhWTD7VyfVxzHM7vMefw","version":"1"}
 {"action":{"base":"brHJbQhd4Mg80tjbtQ1TNA","target":"jyZvmmb979xMp6W9FZC0lg","type":"MERGE_IDENTITIES"},"ledgerTimestamp":1606417828965,"uuid":"CqZGQ6cJi9Tj2OCBE0GvKg","version":"1"}
 {"action":{"amount":"2468840000000000000000","from":"hgZzKZ1bebWxPTBe8O7KPw","memo":"https://etherscan.io/tx/0xbe9e22226ed6c5d0426da12b8359ea5029f5baa2bb3697e3d2b59406cd9ddf4d","to":"Ec60d6PWymrN0ylmsZOHkg","type":"TRANSFER_GRAIN"},"ledgerTimestamp":1606418456898,"uuid":"TKgHlsYjiyZDvWLUpRGc9g","version":"1"}
+{"action":{"amount":"2500000000000000000000","from":"Y8UATyyFzleHMGVMrG83NA","memo":"Monthly LB to Joie Transfer (November)","to":"u72RYlvfPYqRsMyKOEQ6FQ","type":"TRANSFER_GRAIN"},"ledgerTimestamp":1606427262107,"uuid":"fzLIvRvTvGtWE2eaWjxUgA","version":"1"}


### PR DESCRIPTION
LB transfers Joie 2500g every month. 
this covers November