### PR TITLE
Update Cred/Grain configuration

### DIFF
--- a/config/dependencies.json
+++ b/config/dependencies.json
@@ -3,11 +3,6 @@
         "autoActivateOnIdentityCreation": true,
         "id": "Ec60d6PWymrN0ylmsZOHkg",
         "name": "sourcecred",
-        "periods": [
-            {
-                "startTime": "2020-09-06",
-                "weight": 0.1
-            }
-        ]
+        "periods": []
     }
 ]

--- a/config/grain.json
+++ b/config/grain.json
@@ -1,7 +1,7 @@
 {
   "immediatePerWeek": 0,
-  "balancedPerWeek": 0,
-  "recentPerWeek": 15000,
+  "balancedPerWeek": 5000,
+  "recentPerWeek": 20000,
   "recentWeeklyDecayRate": 0.16,
   "maxSimultaneousDistributions": 100
 }


### PR DESCRIPTION
This PR has two commits which change our Cred and Grain configuration:

1. We no longer mint Cred for the @sourcecred account. We did that as a way of providing Grain funding for the SC treasury, but we're going to use a different mechanism for that going forward.
2. We boost the weekly Grain issuance back up to 25k. This is where it was before the holiday bonus. I've switched the payout to be 20k to RECENT and 5k for BALANCED.