### PR TITLE
Auto-commit Grain Distributions to main

### DIFF
--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -43,18 +43,14 @@ jobs:
           description="${description//$'\r'/'%0D'}"
           echo "::set-output name=pr_body::$description"
           rm grain_output.txt
-
-      - name: Create commit and PR for ledger changes
-        id: pr
-        uses: peter-evans/create-pull-request@v3
-        with:
-          branch: generated-ledger
-          branch-suffix: timestamp
-          committer: credbot <credbot@users.noreply.github.com>
-          # author appears to be overridden when the default github action
-          # token is used for checkout
-          author: credbot <credbot@users.noreply.github.com>
-          commit-message: update calculated ledger
-          title: ${{ env.PULL_REQUEST_TITLE }}
-          body: ${{ steps.pr_details.outputs.pr_body }}
-          reviewers: decentralion
+          
+      - name: Commit ledger changes
+        run: |
+          git config user.name 'credbot'
+          git config user.email 'credbot@users.noreply.github.com'
+          git add data/ledger.json
+          git commit --allow-empty -m '${{ env.PULL_REQUEST_TITLE }}' -m '${{ steps.pr_details.outputs.pr_body }}'
+          
+      - name: Push Ledger
+        run: |
+          git push


### PR DESCRIPTION
# Description
This change will cause grain distributions to automatically commit to master, instead of setting up a PR.

This is justified because:
1. There is a strong need for better reliability in payout timeliness
2. The risk of attacks/bugs is low, and ultimately fixable via ledger hand-editing.

# Test plan
I ran it with success in another branch:
https://github.com/sourcecred/cred/commits/grain-trigger-auto

# Open questions:
1. Will it work in the `master` branch even though master is a protected branch? (Are the permissions prepared?)