### PR TITLE
Revert "Auto-commit Grain Distributions to main"

### DIFF
--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -43,14 +43,18 @@ jobs:
           description="${description//$'\r'/'%0D'}"
           echo "::set-output name=pr_body::$description"
           rm grain_output.txt
-          
-      - name: Commit ledger changes
-        run: |
-          git config user.name 'credbot'
-          git config user.email 'credbot@users.noreply.github.com'
-          git add data/ledger.json
-          git commit --allow-empty -m '${{ env.PULL_REQUEST_TITLE }}' -m '${{ steps.pr_details.outputs.pr_body }}'
-          
-      - name: Push Ledger
-        run: |
-          git push
+
+      - name: Create commit and PR for ledger changes
+        id: pr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: generated-ledger
+          branch-suffix: timestamp
+          committer: credbot <credbot@users.noreply.github.com>
+          # author appears to be overridden when the default github action
+          # token is used for checkout
+          author: credbot <credbot@users.noreply.github.com>
+          commit-message: update calculated ledger
+          title: ${{ env.PULL_REQUEST_TITLE }}
+          body: ${{ steps.pr_details.outputs.pr_body }}
+          reviewers: decentralion


### PR DESCRIPTION
Reverts sourcecred/cred#209

Pushing directly to master is blocked, as it should be. We are going to take a different approach to auto-grain.