### PR TITLE
Commit Grain Distributions Directly: attempt 2

### DIFF
--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.ADMIN_TOKEN }}
 
       - name: Install Packages 🔧
         run: |
@@ -44,17 +46,12 @@ jobs:
           echo "::set-output name=pr_body::$description"
           rm grain_output.txt
 
-      - name: Create commit and PR for ledger changes
-        id: pr
-        uses: peter-evans/create-pull-request@v3
-        with:
-          branch: generated-ledger
-          branch-suffix: timestamp
-          committer: credbot <credbot@users.noreply.github.com>
-          # author appears to be overridden when the default github action
-          # token is used for checkout
-          author: credbot <credbot@users.noreply.github.com>
-          commit-message: update calculated ledger
-          title: ${{ env.PULL_REQUEST_TITLE }}
-          body: ${{ steps.pr_details.outputs.pr_body }}
-          reviewers: panchomiguel
+      - name: Commit ledger changes
+        run: |
+          git config user.name 'credbot'
+          git config user.email 'credbot@users.noreply.github.com'
+          git add data/ledger.json
+          git commit --allow-empty -m '${{ env.PULL_REQUEST_TITLE }}' -m '${{ steps.pr_details.outputs.pr_body }}'
+
+      - name: Push Ledger
+        run: git push

--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -33,9 +33,9 @@ jobs:
         run: yarn grain > grain_output.txt
 
       - name: Set environment variables
-        id: pr_details
+        id: details
         run: |
-          echo "PULL_REQUEST_TITLE=Scheduled grain distribution for week ending $(date +"%B %dth, %Y")" >> $GITHUB_ENV
+          echo "COMMIT_TITLE=Scheduled grain distribution for week ending $(date +"%B %dth, %Y")" >> $GITHUB_ENV
           description="This PR was auto-generated on $(date +%d-%m-%Y) \
             to add the latest grain distribution to our instance.
 
@@ -43,7 +43,7 @@ jobs:
           description="${description//'%'/'%25'}"
           description="${description//$'\n'/'%0A'}"
           description="${description//$'\r'/'%0D'}"
-          echo "::set-output name=pr_body::$description"
+          echo "::set-output name=commit_body::$description"
           rm grain_output.txt
 
       - name: Commit ledger changes
@@ -51,7 +51,7 @@ jobs:
           git config user.name 'credbot'
           git config user.email 'credbot@users.noreply.github.com'
           git add data/ledger.json
-          git commit --allow-empty -m '${{ env.PULL_REQUEST_TITLE }}' -m '${{ steps.pr_details.outputs.pr_body }}'
+          git commit --allow-empty -m '${{ env.COMMIT_TITLE }}' -m '${{ steps.details.outputs.commit_body }}'
 
       - name: Push Ledger
         run: git push


### PR DESCRIPTION
# Description

Grain distributions should be committed directly to avoid merge
conflicts and ensure reliably-timed distributions for the community.

The action will utilize a configured `ADMIN_TOKEN` secret in the github
repo to ensure the action has permissions to commit directly to master
on scheduled runs. The user of the token must have admin permissions in
the repo and the token utilized must have permissions to push to public
repositories:
![Screenshot from 2021-01-28 12-13-46](https://user-images.githubusercontent.com/17910833/106180883-85897700-6162-11eb-9220-d739cd2e8abd.png)
# Test Plan
ensured committing to a protected branch worked in a forked
topocount/cred repo using a simple autocommit action