### PR TITLE
Add package.json to gh-pages branch so you can checkout and serve

### DIFF
--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           yarn sourcecred site
           rm -rf ./site/{output,data,config,sourcecred.json}
-          cp -r ./{output,data,config,sourcecred.json} ./site/
+          cp -r ./{output,data,config,sourcecred.json,package.json} ./site/
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1


### PR DESCRIPTION
I want to be able to locally serve the gh-pages branch, so that I can play with prod scores/graphs without having to run `load`. Currently, this is really annoying to do: you have to copy files across branches since the gh-pages branch is missing the package.json file. So this PR copies the package file into the deployed site so that it is present in the generate gh-pages branch.

I chose not to copy the yarn.lock file as well, and it worked without. Not sure if I should also include the yarn.lock file or if it's ok without.

# Test plan
1. Pushed [a test branch](https://github.com/sourcecred/cred/tree/gh-pages-serve-test) to set off a deployment to [a test deployment branch](https://github.com/sourcecred/cred/tree/gh-pages-test)
2. Went to https://github.com/sourcecred/cred/settings and configured github pages to point to the test deployment branch
3. Verified that http://cred.sourcecred.io/ still worked
4. (changed the settings back)

Then,
```
git checkout origin/gh-pages-test
yarn start
ctrl-c
yarn serve
```
Verified the UI works and shows latest data.