### PR TITLE
Change default grain distribution reviewer

### DIFF
--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -57,4 +57,4 @@ jobs:
           commit-message: update calculated ledger
           title: ${{ env.PULL_REQUEST_TITLE }}
           body: ${{ steps.pr_details.outputs.pr_body }}
-          reviewers: decentralion
+          reviewers: panchomiguel


### PR DESCRIPTION
Switching the default reviewer to @panchomiguel, as he is treasurer.