### PR TITLE
Add `pako` to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "dotenv-cli": "^4.0.0",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "pako": "^2.0.3"
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/40803711/112643755-15723700-8e1b-11eb-9be2-71050dee042e.png)

On release `v0.8.1` pako module was introduced, and it's required to generate the instance. So I'm adding it as a dev dependency so it works again.

I already made this change on `1Hive/pollen` and it worked as expected.