### PR TITLE
Add workflow-dispatch for grain distributions

### DIFF
--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -10,6 +10,10 @@ on:
       # PRSs created from grain-trigger-* branches are targeted
       # on their immediate base branches, as opposed to master
       - "grain-trigger-*"
+  # Adds a button to manually trigger a distribution attempt.
+  # If grain has been distributed for the most recently completed week
+  # the task will be idempotent.
+  workflow_dispatch:
 
 jobs:
   distribute-grain:


### PR DESCRIPTION
This enables grain distributions to be triggered manually from the UI, but only by contributors
with write access.