### PR TITLE
Add analysis command to instance generation

### DIFF
--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -30,6 +30,9 @@ jobs:
         env:
           SOURCECRED_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOURCECRED_DISCORD_TOKEN: ${{ secrets.SOURCECRED_DISCORD_TOKEN }}
+      
+      - name: Generate Optional Analysis Files
+        run: yarn sourcecred analysis
 
       - name: Generate Frontend 🏗
         run: |


### PR DESCRIPTION
0.8.5 included an analysis command that generates the accounts.json
This adds it to the github action so that our gh-pages branch will contain an accounts.json
We don't really need it right now, this is more to make sure it works so that other communities can copy this PR for their own instance.