### PR TITLE
Update Workflows to use our Github Secret

### DIFF
--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Load Data and Compute Cred 🧮
         run: yarn sourcecred go
         env:
-          SOURCECRED_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCECRED_GITHUB_TOKEN: ${{ secrets.SOURCECRED_GITHUB_TOKEN }}
           SOURCECRED_DISCORD_TOKEN: ${{ secrets.SOURCECRED_DISCORD_TOKEN }}
 
       - name: Distribute Grain 💸

--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Load Data and Compute Cred 🧮
         run: yarn sourcecred go
         env:
-          SOURCECRED_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCECRED_GITHUB_TOKEN: ${{ secrets.SOURCECRED_GITHUB_TOKEN }}
           SOURCECRED_DISCORD_TOKEN: ${{ secrets.SOURCECRED_DISCORD_TOKEN }}
-      
+
       - name: Generate Optional Analysis Files
         run: yarn sourcecred analysis
 
@@ -43,6 +43,6 @@ jobs:
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SOURCECRED_GITHUB_TOKEN }}
           branch: gh-pages
           folder: site


### PR DESCRIPTION
see https://github.com/sourcecred/template-instance/pull/72 for reference.

This prevents any latent bugs. if we ever decide to start generating cred from private repos (not likely), but more importantly, it also bring us inline with the template instance and will allow for less confusion when others are looking at our work for reference.

test plan: the workflow should pass on merge
