### PR TITLE
Add cache to actions deployment (experiment)

### DIFF
--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Generate Frontend 🏗
         run: |
           yarn sourcecred site
-          rm -rf ./site/{output,data,config,sourcecred.json,package.json,yarn.lock}
-          cp -r ./{output,data,config,sourcecred.json,package.json,yarn.lock} ./site/
+          rm -rf ./site/{output,data,config,sourcecred.json,package.json,yarn.lock,cache}
+          cp -r ./{output,data,config,sourcecred.json,package.json,yarn.lock,cache} ./site/
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.1


### PR DESCRIPTION
This will allow `graph` CLI to be run from a fresh clone, making a lot of weights and code experimentation easier.

-----
To review the ledger in a more human readable format:

https://observablehq.com/@blueridger/sourcecred-ledger-viewer?repoAndBranch=sourcecred/cred/BRANCH-NAME-HERE
