### PR TITLE
Add DS_STORE to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ output/
 cache/
 
 .env
+**/.DS_Store
+**/.DS_Store?


### PR DESCRIPTION
Based on this doc: https://git-scm.com/docs/gitignore

Miguel saw one appear in root as well as /config, so I added ** to the matcher. I think that's right?