### PR TITLE
Force gh-pages to only have one commit

### DIFF
--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -41,8 +41,9 @@ jobs:
           cp -r ./{output,data,config,sourcecred.json,package.json,yarn.lock,cache} ./site/
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@4.1.1
+        uses: JamesIves/github-pages-deploy-action@4.1.3
         with:
           token: ${{ secrets.SOURCECRED_GITHUB_TOKEN }}
           branch: gh-pages
           folder: site
+          single-commit: true


### PR DESCRIPTION
Looking at the current uses and the transparency needed around the process, the most relevant parts seem to be in the ledger file and the other config files in the main branch, gh-pages serves a utility part only, I'm suggesting we put this single commit because it would mean lower times while cloning the repo, since it's growing data