### PR TITLE
Revert "Update to main in initiatives plugin"

### DIFF
--- a/config/plugins/sourcecred/initiatives/config.json
+++ b/config/plugins/sourcecred/initiatives/config.json
@@ -1,1 +1,1 @@
-{"remoteUrl": "https://github.com/sourcecred/cred/tree/main/initiatives"}
+{"remoteUrl": "https://github.com/sourcecred/cred/tree/master/initiatives"}


### PR DESCRIPTION
Soooo... This caused a bug after all: https://github.com/sourcecred/cred/runs/3417010762?check_suite_focus=true#step:5:226

Since all the initiatives are cross-linked by url, we'd have to refactor all the references instead of just this one.

Tested this revert by checking out this branch and then running `git checkout gh-pages cache && yarn start`
Also tested that the initiatives are actually working by removing it from sourcecred.json and ensuring that scores change. So strange that they work with the wrong branch name! This plugin is a mystery to me.

Reverts sourcecred/cred#336