### PR TITLE
Add .gitignore to gh-pages deployment

### DIFF
--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Generate Frontend 🏗
         run: |
           yarn sourcecred site
-          rm -rf ./site/{output,data,config,sourcecred.json,package.json,yarn.lock,cache}
-          cp -r ./{output,data,config,sourcecred.json,package.json,yarn.lock,cache} ./site/
+          rm -rf ./site/{output,data,config,sourcecred.json,package.json,yarn.lock,cache,.gitignore}
+          cp -r ./{output,data,config,sourcecred.json,package.json,yarn.lock,cache,.gitignore} ./site/
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.1


### PR DESCRIPTION
I used the gh-pages branch as a test instance A LOT. This will help keep my workspace clean as I do so. Will be tested after merge.