### PR TITLE
End all PL sponsorships

### DIFF
--- a/config/personalAttributions.json
+++ b/config/personalAttributions.json
@@ -24,6 +24,10 @@
                     {
                         "decimalProportion": 0.2,
                         "startDate": "2/1/2018"
+                    },
+                    {
+                        "decimalProportion": 0,
+                        "startDate": "11/1/2021"
                     }
                 ],
                 "toParticipantId": "DaIYqzL6bD8Fri2ZYcXVsQ",
@@ -40,6 +44,10 @@
                     {
                         "decimalProportion": 0.2,
                         "startDate": "8/1/2020"
+                    },
+                    {
+                        "decimalProportion": 0,
+                        "startDate": "11/1/2021"
                     }
                 ],
                 "toParticipantId": "DaIYqzL6bD8Fri2ZYcXVsQ",
@@ -96,6 +104,10 @@
                     {
                         "decimalProportion": 0.2,
                         "startDate": "6/1/2021"
+                    },
+                    {
+                        "decimalProportion": 0,
+                        "startDate": "11/1/2021"
                     }
                 ],
                 "toParticipantId": "DaIYqzL6bD8Fri2ZYcXVsQ",


### PR DESCRIPTION
The funding agreement I just signed contains the following clause:

> WHEREAS, Protocol Labs provided open source development grants to certain individuals to fund their open source contributions to the Project, and all of the grants have expired on their own terms; 

So we can count the sponsorships as done, which is great because they were a semantic misuse of personal attributions.

-----
### Resources for Reviewers
[Human-Readable Ledger Diff](https://observablehq.com/@sourcecred/sourcecred-ledger-viewer?repo=sourcecred/cred)

[Grain Sale Request Spreadsheet](https://docs.google.com/spreadsheets/d/1emY35TXD5fiCZJFZooPy-NjvchzFDoiWDw8LJMXT_Es/edit#gid=156078179)

[Opt-in Spreadsheet](https://docs.google.com/spreadsheets/d/1Az-Cew-rFG9S6Yo55GnjNIy7bssHvtrTtF45yeoxFtw/edit#gid=1048967430)
