### PR TITLE
Wipe actions cache

### DIFF
--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/cache@v2.1.4
         with:
           path: '**/cache'
-          key: SC-${{ runner.os }}-${{ hashFiles('**/config.json', '**/sourcecred.json', '**/yarn.lock') }}
+          key: SC-${{ runner.os }}-v2-${{ hashFiles('**/config.json', '**/sourcecred.json', '**/yarn.lock') }}
 
       - name: Install Packages 🔧
         run: yarn --frozen-lockfile


### PR DESCRIPTION
We are getting a consistent 404 that might be affecting cred scores. This will wipe the actions cache. From what I can tell by the error, this will likely fix it. https://github.com/sourcecred/cred/runs/4437776446?check_suite_focus=true

-----
### Resources for Reviewers
[Human-Readable Ledger Diff](https://observablehq.com/@sourcecred/sourcecred-ledger-viewer?repo=sourcecred/cred)

[Grain Sale Request Spreadsheet](https://docs.google.com/spreadsheets/d/1emY35TXD5fiCZJFZooPy-NjvchzFDoiWDw8LJMXT_Es/edit#gid=156078179)

[Opt-in Spreadsheet](https://docs.google.com/spreadsheets/d/1Az-Cew-rFG9S6Yo55GnjNIy7bssHvtrTtF45yeoxFtw/edit#gid=1048967430)
